### PR TITLE
feat: add lint PR GitHub workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: Lint PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
## WHY

To maintain PRs.
It should follow the convestional messages.
