### PR TITLE
Fix provider binary not found error handling

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -15,10 +15,12 @@ var (
 	ErrModuleNotExist = errors.New("module not exist")
 
 	// Provider
-	ErrProviderBinaryNotExist  = errors.New("provider binary not exist")
-	ErrProviderGPGKeyNotExist  = errors.New("provider gpg key not exist")
-	ErrProviderNotExist        = errors.New("provider not exist")
-	ErrProviderVersionNotExist = errors.New("provider version not exist")
+	ErrProviderBinaryNotExist        = errors.New("provider binary not exist")
+	ErrProviderGPGKeyNotExist        = errors.New("provider gpg key not exist")
+	ErrProviderSHA256SUMSNotExist    = errors.New("sha256 sum key not exist")
+	ErrProviderSHA256SUMSSigNotExist = errors.New("sha256 sum sig key not exist")
+	ErrProviderNotExist              = errors.New("provider not exist")
+	ErrProviderVersionNotExist       = errors.New("provider version not exist")
 
 	PlatformBinaryRegex = regexp.MustCompile(`terraform-provider-(\w+)_([0-9]+.[0-9]+.[0-9]+)_(\w+)_(\w+).zip`)
 )

--- a/internal/driver/s3/s3.go
+++ b/internal/driver/s3/s3.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/kerraform/kegistry/internal/driver"
 	"go.uber.org/zap"
 )
@@ -67,4 +69,17 @@ func NewDriver(logger *zap.Logger, opts *DriverOpts) (*driver.Driver, error) {
 		Module:   module,
 		Provider: provider,
 	}, nil
+}
+
+func handleError(err error, rerr error) error {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.(type) {
+		case *types.NotFound:
+		case *types.NoSuchKey:
+			return rerr
+		}
+	}
+
+	return err
 }

--- a/internal/v1/provider/provider.go
+++ b/internal/v1/provider/provider.go
@@ -232,6 +232,12 @@ func (p *Provider) DownloadPlatformBinary() http.Handler {
 
 		f, err := p.driver.Provider.GetPlatformBinary(r.Context(), namespace, registryName, version, os, arch)
 		if err != nil {
+			if errors.Is(err, driver.ErrProviderNotExist) ||
+				errors.Is(err, driver.ErrProviderSHA256SUMSNotExist) ||
+				errors.Is(err, driver.ErrProviderSHA256SUMSSigNotExist) {
+				return kerrors.Wrap(err, kerrors.WithNotFound())
+			}
+
 			return err
 		}
 		defer f.Close()


### PR DESCRIPTION
## WHY

In the previous implementation, the registry returned `500` on any errors.
But, it should return `404` on binary not found.